### PR TITLE
Refatora a função init

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -1,0 +1,17 @@
+import * as crypto from 'crypto'
+
+export function generateKeyAndSignature(
+	password: string,
+	saltString?: string
+): [Buffer, string, Buffer] {
+	let salt
+	if (saltString == undefined) salt = crypto.randomBytes(16)
+	else salt = Buffer.from(saltString, 'base64')
+
+	const key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+	const hmac = crypto.createHmac('sha256', key)
+	hmac.update(salt)
+	const sign = hmac.digest('base64')
+
+	return [key, sign, salt]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,53 +1,12 @@
 import Conf from 'conf'
-import { prompt } from 'enquirer'
-import * as crypto from 'crypto'
 
+import signInOrSignUp from './signInOrSignUp'
 import menu from './menu/index'
 
 async function run() {
 	const config = new Conf()
-	let key = await init()
+	let key = await signInOrSignUp(config)
 	if (key !== null) while (key = await menu(config, key)) { }
-
-	async function init() {
-		const { password } = (await prompt({
-			type: 'password',
-			name: 'password',
-			message: 'Master password',
-		})) as { password: string }
-
-		let key = null
-
-		if (config.has('salt') && config.has('sign')) {
-			const salt = Buffer.from(config.get('salt') as string, 'base64')
-			key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
-
-			const hmac = crypto.createHmac('sha256', key)
-			hmac.update(salt)
-			const sign = hmac.digest('base64')
-
-			if (sign !== config.get('sign')) {
-				console.log('invalid password')
-				return null
-			} else console.log('password ok')
-		} else {
-			const salt = crypto.randomBytes(16)
-			key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
-
-			const hmac = crypto.createHmac('sha256', key)
-			hmac.update(salt)
-			const sign = hmac.digest('base64')
-
-			config.set({
-				salt: salt.toString('base64'),
-				sign,
-			})
-
-			console.log('setup complete')
-		}
-
-		return key!
-	}
 }
 
 run()

--- a/src/signInOrSignUp.ts
+++ b/src/signInOrSignUp.ts
@@ -1,0 +1,45 @@
+import Conf from 'conf/dist/source'
+import { prompt } from 'enquirer'
+import * as crypto from 'crypto'
+
+async function signInOrSignUp(config: Conf) {
+	const { password } = (await prompt({
+		type: 'password',
+		name: 'password',
+		message: 'Master password',
+	})) as { password: string }
+
+	let key = null
+
+	if (config.has('salt') && config.has('sign')) {
+		const salt = Buffer.from(config.get('salt') as string, 'base64')
+		key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+
+		const hmac = crypto.createHmac('sha256', key)
+		hmac.update(salt)
+		const sign = hmac.digest('base64')
+
+		if (sign !== config.get('sign')) {
+			console.log('invalid password')
+			return null
+		} else console.log('password ok')
+	} else {
+		const salt = crypto.randomBytes(16)
+		key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+
+		const hmac = crypto.createHmac('sha256', key)
+		hmac.update(salt)
+		const sign = hmac.digest('base64')
+
+		config.set({
+			salt: salt.toString('base64'),
+			sign,
+		})
+
+		console.log('setup complete')
+	}
+
+	return key!
+}
+
+export default signInOrSignUp

--- a/src/signInOrSignUp.ts
+++ b/src/signInOrSignUp.ts
@@ -2,6 +2,39 @@ import Conf from 'conf/dist/source'
 import { prompt } from 'enquirer'
 import * as crypto from 'crypto'
 
+function signIn(config: Conf, password: string) {
+	const salt = Buffer.from(config.get('salt') as string, 'base64')
+	const key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+
+	const hmac = crypto.createHmac('sha256', key)
+	hmac.update(salt)
+	const sign = hmac.digest('base64')
+
+	if (sign !== config.get('sign')) {
+		console.log('invalid password')
+		return null
+	} else console.log('password ok')
+
+	return key
+}
+
+function signUp(config: Conf, password: string) {
+	const salt = crypto.randomBytes(16)
+	const key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+
+	const hmac = crypto.createHmac('sha256', key)
+	hmac.update(salt)
+	const sign = hmac.digest('base64')
+
+	config.set({
+		salt: salt.toString('base64'),
+		sign,
+	})
+
+	console.log('setup complete')
+	return key
+}
+
 async function signInOrSignUp(config: Conf) {
 	const { password } = (await prompt({
 		type: 'password',
@@ -9,37 +42,9 @@ async function signInOrSignUp(config: Conf) {
 		message: 'Master password',
 	})) as { password: string }
 
-	let key = null
-
-	if (config.has('salt') && config.has('sign')) {
-		const salt = Buffer.from(config.get('salt') as string, 'base64')
-		key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
-
-		const hmac = crypto.createHmac('sha256', key)
-		hmac.update(salt)
-		const sign = hmac.digest('base64')
-
-		if (sign !== config.get('sign')) {
-			console.log('invalid password')
-			return null
-		} else console.log('password ok')
-	} else {
-		const salt = crypto.randomBytes(16)
-		key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
-
-		const hmac = crypto.createHmac('sha256', key)
-		hmac.update(salt)
-		const sign = hmac.digest('base64')
-
-		config.set({
-			salt: salt.toString('base64'),
-			sign,
-		})
-
-		console.log('setup complete')
-	}
-
-	return key!
+	const hasAccount = config.has('salt') && config.has('sign')
+	if (hasAccount) return signIn(config, password)
+	return signUp(config, password)
 }
 
 export default signInOrSignUp

--- a/src/signInOrSignUp.ts
+++ b/src/signInOrSignUp.ts
@@ -1,36 +1,28 @@
 import Conf from 'conf/dist/source'
 import { prompt } from 'enquirer'
-import * as crypto from 'crypto'
+
+import { generateKeyAndSignature } from './crypto'
 
 function signIn(config: Conf, password: string) {
-	const salt = Buffer.from(config.get('salt') as string, 'base64')
-	const key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
-
-	const hmac = crypto.createHmac('sha256', key)
-	hmac.update(salt)
-	const sign = hmac.digest('base64')
-
+	const [key, sign] = generateKeyAndSignature(
+		password,
+		config.get('salt') as string
+	)
 	if (sign !== config.get('sign')) {
 		console.log('invalid password')
 		return null
-	} else console.log('password ok')
-
-	return key
+	} else {
+		console.log('password ok')
+		return key
+	}
 }
 
 function signUp(config: Conf, password: string) {
-	const salt = crypto.randomBytes(16)
-	const key = crypto.pbkdf2Sync(password, salt, 100000, 32, 'sha256')
-
-	const hmac = crypto.createHmac('sha256', key)
-	hmac.update(salt)
-	const sign = hmac.digest('base64')
-
+	const [key, sign, salt] = generateKeyAndSignature(password)
 	config.set({
 		salt: salt.toString('base64'),
 		sign,
 	})
-
 	console.log('setup complete')
 	return key
 }


### PR DESCRIPTION
- Renomear a função para `signInOrSignUp` já que ela é responsável pelo login ou criação da conta
- Mover a função para o próprio arquivo com contexto mais coerente
- Extrair predicado `hasAccount` para explicitar o propósito do condicional
- Extrair os trechos de códigos de login e criação da conta para suas próprias funções, `signIn` e `signUp` respectivamente
- Extrair função `generateKeyAndSignature` já que as funções de `signIn`
e de `signOut` utilizavam códigos duplicados